### PR TITLE
Clean .select2-selection.select2-selection--single:before

### DIFF
--- a/css/jquery-glpi.css
+++ b/css/jquery-glpi.css
@@ -221,7 +221,6 @@ html .ui-autocomplete {
    max-width: 270px;
 }
 .select2-selection.select2-selection--single:before {
-   content: '\02026';
    position: absolute;
    z-index: 1;
    left: -1em;


### PR DESCRIPTION
This is creating a dot in all select items if the language isnt english:
        
            content: '\02026';

So i deleted.  Check image:

https://imgur.com/a/jpoXhMD

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
